### PR TITLE
ページタブにモブタイマー時間を表示するように修正

### DIFF
--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -95,6 +95,7 @@ import Notifier from './Notifier';
   }
 
   function updateTime(sec: number) {
+    document.title = secondToDisplayTime(sec);
     document.getElementsByClassName(
       'time'
     )[0].textContent = secondToDisplayTime(sec);


### PR DESCRIPTION
ページタイトルにモブタイマーが表示されていると便利そうだなと思ったので修正してみました！

<img width="486" alt="スクリーンショット 2019-08-20 16 28 00" src="https://user-images.githubusercontent.com/17094072/63326597-8b710b00-c367-11e9-87d6-978866b6590a.png">
